### PR TITLE
Fix all Django 1.8 warnings

### DIFF
--- a/example_module/nexus_modules.py
+++ b/example_module/nexus_modules.py
@@ -1,3 +1,5 @@
+from django.conf.urls.defaults import url
+
 import nexus
 
 
@@ -9,14 +11,9 @@ class HelloWorldModule(nexus.NexusModule):
         return 'Hello World'
 
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url
-
-        urlpatterns = patterns(
-            '',
+        return [
             url(r'^$', self.as_view(self.index), name='index'),
-        )
-
-        return urlpatterns
+        ]
 
     def render_on_dashboard(self, request):
         return self.render_to_string('nexus/example/dashboard.html', {

--- a/nexus/compat.py
+++ b/nexus/compat.py
@@ -1,3 +1,5 @@
+import django
+
 # Django <1.9 provides importlib for Python <2.6
 try:
     from importlib import import_module  # noqa
@@ -36,3 +38,31 @@ except ImportError:
 
     def register():
         pass
+
+# context_processors moved in Django 1.8
+try:
+    from django.template import context_processors  # noqa
+except ImportError:
+    from django.core import context_processors  # noqa
+
+
+# 'dictionary' -> 'context' in Django 1.8
+if django.VERSION[:2] >= (1, 8):
+    from django.shortcuts import render
+    from django.template.loader import render_to_string
+else:
+    from django.shortcuts import render as orig_render
+    from django.template import RequestContext
+    from django.template.loader import render_to_string as orig_render_to_string
+
+    def render(*args, **kwargs):
+        if 'context' in kwargs:
+            kwargs['dictionary'] = kwargs.pop('context')
+        return orig_render(*args, **kwargs)
+
+    def render_to_string(*args, **kwargs):
+        if 'context' in kwargs:
+            kwargs['dictionary'] = kwargs.pop('context')
+        if 'request' in kwargs:
+            kwargs['context_instance'] = RequestContext(kwargs.pop('request'))
+        return orig_render_to_string(*args, **kwargs)

--- a/nexus/modules.py
+++ b/nexus/modules.py
@@ -110,12 +110,7 @@ class NexusModule(object):
         return self.get_title()
 
     def get_urls(self):
-        try:
-            from django.conf.urls import patterns
-        except ImportError:  # Django<=1.4
-            from django.conf.urls.defaults import patterns
-
-        return patterns('')
+        return []
 
     def urls(self):
         if self.app_name and self.name:

--- a/nexus/templates/nexus/admin/change_form.html
+++ b/nexus/templates/nexus/admin/change_form.html
@@ -1,5 +1,4 @@
 {% extends "nexus/admin/base_site.html" %}
-{% load url from future %}
 {% load i18n admin_modify adminmedia %}
 {% load nexus_admin %}
 

--- a/nexus/templates/nexus/admin/change_list.html
+++ b/nexus/templates/nexus/admin/change_list.html
@@ -1,5 +1,4 @@
 {% extends "nexus/admin/base_site.html" %}
-{% load url from future %}
 {% load adminmedia admin_list i18n %}
 
 {% block head %}
@@ -63,7 +62,7 @@
                     </div>
                 {% endif %}
             {% endblock %}
-        
+
             <form id="changelist-form" action="" method="post"{% if cl.formset.is_multipart %} enctype="multipart/form-data"{% endif %}>{% csrf_token %}
             {% if cl.formset %}
                 {{ cl.formset.management_form }}

--- a/nexus/templates/nexus/base.html
+++ b/nexus/templates/nexus/base.html
@@ -1,4 +1,4 @@
-{% load nexus_helpers %}{% load url from future %}
+{% load nexus_helpers %}
 <!DOCTYPE html>
 
 <html>

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -32,6 +32,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
 import nexus
@@ -6,7 +6,6 @@ import nexus
 admin.autodiscover()
 nexus.autodiscover()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^nexus/', include(nexus.site.urls)),
-)
+]


### PR DESCRIPTION
Changed `tox` so all tests ran with `python -Werror`. Found a set of warnings to fix on both Django 1.7 and 1.8:
- Fix context_processors moved warning
- Fix SessionAuthenticationMiddleware warning
- Remove 'load url from future'
- Fix urls and template rendering
