### PR TITLE
Remove old compat imports

### DIFF
--- a/nexus/__init__.py
+++ b/nexus/__init__.py
@@ -41,8 +41,9 @@ def autodiscover(site=None):
         globals()['site'] = locals()['site']
 
     import imp
+    from importlib import import_module
+
     from django.conf import settings
-    from nexus.compat import import_module
 
     for app in settings.INSTALLED_APPS:
         # For each app, we need to look for an api.py inside that app's

--- a/nexus/checks.py
+++ b/nexus/checks.py
@@ -1,8 +1,7 @@
 import django
 from django.conf import settings
+from django.core.checks import Error, Tags, register
 from django.core.exceptions import ImproperlyConfigured
-
-from nexus.compat import Error, Tags, register
 
 
 def register_checks():

--- a/nexus/compat.py
+++ b/nexus/compat.py
@@ -1,44 +1,5 @@
 import django
 
-# Django <1.9 provides importlib for Python <2.6
-try:
-    from importlib import import_module  # noqa
-except ImportError:
-    from django.utils.importlib import import_module  # noqa
-
-# Django <1.9 provides SortedDict on older versions for Python < 2.6
-try:
-    from collections import OrderedDict  # noqa
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict  # noqa
-
-# Django <1.6 provides update_wrapper for Python < 2.6
-try:
-    from functools import update_wrapper  # noqa
-except ImportError:
-    from django.utils.functional import update_wrapper  # noqa
-
-# Checks framework only exists on Django 1.7+
-try:
-    from django.core.checks import Error, Tags, register
-except ImportError:
-    class CheckMessage(object):
-        def __init__(self, level, msg, hint=None, obj=None, id=None):
-            self.level = level
-            self.msg = msg
-            self.hint = hint
-            self.obj = obj
-            self.id = id
-
-    class Error(CheckMessage):
-        def __init__(self, *args, **kwargs):
-            super(Error, self).__init__(40, *args, **kwargs)
-
-    Tags = object()
-
-    def register():
-        pass
-
 # context_processors moved in Django 1.8
 try:
     from django.template import context_processors  # noqa

--- a/nexus/sites.py
+++ b/nexus/sites.py
@@ -4,6 +4,8 @@ import os
 import posixpath
 import stat
 import urllib
+from collections import OrderedDict
+from functools import update_wrapper
 
 from django.conf.urls import include, url
 from django.core.urlresolvers import reverse
@@ -14,7 +16,7 @@ from django.views.decorators.csrf import csrf_protect
 from django.views.static import was_modified_since
 
 from nexus import conf
-from nexus.compat import OrderedDict, context_processors, render, render_to_string, update_wrapper
+from nexus.compat import context_processors, render, render_to_string
 
 NEXUS_ROOT = os.path.normpath(os.path.dirname(__file__))
 

--- a/nexus/templatetags/nexus_helpers.py
+++ b/nexus/templatetags/nexus_helpers.py
@@ -1,8 +1,9 @@
+from collections import OrderedDict
+
 from django import template
 
 import nexus
 from nexus import conf
-from nexus.compat import OrderedDict
 from nexus.modules import NexusModule
 
 register = template.Library()


### PR DESCRIPTION
We only support Python 2.7 and Django 1.7 and 1.8, so stop pandering to older versions.
