### PR TITLE
Nexus Settings shadow Django's

### DIFF
--- a/nexus/conf.py
+++ b/nexus/conf.py
@@ -1,6 +1,16 @@
 from django.conf import settings
 
-MEDIA_PREFIX = getattr(settings, 'NEXUS_MEDIA_PREFIX', '/nexus/media/')
 
-if getattr(settings, 'NEXUS_USE_DJANGO_MEDIA_URL', False):
-    MEDIA_PREFIX = getattr(settings, 'MEDIA_URL', MEDIA_PREFIX)
+class Settings(object):
+    """
+    Shadow Django's settings with a little logic
+    """
+
+    @property
+    def MEDIA_PREFIX(self):
+        prefix = getattr(settings, 'NEXUS_MEDIA_PREFIX', '/nexus/media/')
+        if getattr(settings, 'NEXUS_USE_DJANGO_MEDIA_URL', False):
+            prefix = getattr(settings, 'MEDIA_URL', prefix)
+        return prefix
+
+nexus_settings = Settings()  # noqa

--- a/nexus/sites.py
+++ b/nexus/sites.py
@@ -15,8 +15,8 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
 from django.views.static import was_modified_since
 
-from nexus import conf
 from nexus.compat import context_processors, render, render_to_string
+from nexus.conf import nexus_settings
 
 NEXUS_ROOT = os.path.normpath(os.path.dirname(__file__))
 
@@ -114,7 +114,7 @@ class NexusSite(object):
         context.update({
             'request': request,
             'nexus_site': self,
-            'nexus_media_prefix': conf.MEDIA_PREFIX.rstrip('/'),
+            'nexus_media_prefix': nexus_settings.MEDIA_PREFIX.rstrip('/'),
         })
         return context
 

--- a/nexus/templatetags/nexus_helpers.py
+++ b/nexus/templatetags/nexus_helpers.py
@@ -3,14 +3,14 @@ from collections import OrderedDict
 from django import template
 
 import nexus
-from nexus import conf
+from nexus.conf import nexus_settings
 from nexus.modules import NexusModule
 
 register = template.Library()
 
 
 def nexus_media_prefix():
-    return conf.MEDIA_PREFIX.rstrip('/')
+    return nexus_settings.MEDIA_PREFIX.rstrip('/')
 register.simple_tag(nexus_media_prefix)
 
 

--- a/tests/testapp/test_conf.py
+++ b/tests/testapp/test_conf.py
@@ -1,0 +1,11 @@
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+from nexus.conf import nexus_settings
+
+
+class NexusSettingsTests(SimpleTestCase):
+
+    @override_settings(NEXUS_MEDIA_PREFIX='/mynexusprefix/')
+    def test_with_override_settings(self):
+        self.assertEqual(nexus_settings.MEDIA_PREFIX, '/mynexusprefix/')


### PR DESCRIPTION
Using an object that always looks at `django.conf.settings` first allows `override_settings` to work and other runtime changes that import-only fetching did not allow.
