### PR TITLE
Remove global GARGOYLE in Javascript

### DIFF
--- a/nexus/templates/nexus/base.html
+++ b/nexus/templates/nexus/base.html
@@ -13,15 +13,6 @@
 
         <meta name="robots" content="NONE,NOARCHIVE">
 
-        <script>
-            var GARGOYLE = {
-                facebox: {
-                    loadingImage: "{% nexus_media_prefix %}/nexus/img/facebox/loading.gif",
-                    closeImage:   "{% nexus_media_prefix %}/nexus/img/facebox/closelabel.png"
-                }
-            };
-        </script>
-
         <script src="{% nexus_media_prefix %}/nexus/js/lib/jquery.js"></script>
         <script src="{% nexus_media_prefix %}/nexus/js/lib/jquery.tmpl.js"></script>
         <script src="{% nexus_media_prefix %}/nexus/js/lib/facebox/facebox.js"></script>


### PR DESCRIPTION
It was added in 3f357896e96bb24e293b99119bd487df58182315 but Gargoyle redefines these - see https://github.com/YPlan/gargoyle/blob/96109aaa547dd5340e3268016ad6efbef10c3fa6/gargoyle/templates/gargoyle/index.html#L10 .
