### PR TITLE
Fix CSRF protection to work with non-standard CSRF cookie names

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,9 @@ Pending Release
 * Removed the login/logout pages, which were copied and adapted from an old version of Django Admin, and likely no
   longer secure. If you are not logged in Nexus will now redirect you to Django Admin - thus Django Admin is now
   required by Nexus.
+* Fixed Nexus CSRF protection to work if you have changed the CSRF cookie name,
+  thanks to a PR on the original Nexus from Github users @karech and
+  @graingert.
 
 1.0.0 (2015-12-09)
 ------------------

--- a/nexus/media/js/nexus.js
+++ b/nexus/media/js/nexus.js
@@ -34,7 +34,8 @@ jQuery.ajaxSetup({
         }
 
         if (!safeMethod(settings.type) && sameOrigin(settings.url)) {
-            xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+            var cookieName = $('#nexus-constants').data('csrfCookieName');
+            xhr.setRequestHeader("X-CSRFToken", getCookie(cookieName));
         }
     }
 });

--- a/nexus/templates/nexus/base.html
+++ b/nexus/templates/nexus/base.html
@@ -16,7 +16,10 @@
         <script src="{% nexus_media_prefix %}/nexus/js/lib/jquery.js"></script>
         <script src="{% nexus_media_prefix %}/nexus/js/lib/jquery.tmpl.js"></script>
         <script src="{% nexus_media_prefix %}/nexus/js/lib/facebox/facebox.js"></script>
-        <script src="{% nexus_media_prefix %}/nexus/js/nexus.js"></script>
+        <script src="{% nexus_media_prefix %}/nexus/js/nexus.js"
+                id="nexus-constants"
+                data-csrf-cookie-name="{% nexus_csrf_cookie_name %}"
+            ></script>
 
         {% block head %}
         {% endblock %}

--- a/nexus/templatetags/nexus_helpers.py
+++ b/nexus/templatetags/nexus_helpers.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from django import template
+from django.conf import settings
 from django.utils import six
 
 import nexus
@@ -18,6 +19,11 @@ register.simple_tag(nexus_media_prefix)
 def nexus_version():
     return nexus.__version__
 register.simple_tag(nexus_version)
+
+
+def nexus_csrf_cookie_name():
+    return settings.CSRF_COOKIE_NAME
+register.simple_tag(nexus_csrf_cookie_name)
 
 
 def show_navigation(context):


### PR DESCRIPTION
Fixes disqus/nexus#19 with an updated version of disqus/nexus#18 with review changes. Thanks @karech and @graingert.
