### PR TITLE
Remove inline NEXUS definition

### DIFF
--- a/nexus/media/js/lib/facebox/facebox.js
+++ b/nexus/media/js/lib/facebox/facebox.js
@@ -81,19 +81,22 @@
    * Public, $.facebox methods
    */
 
+  var nexusMediaPreix = $('#nexus-facebox-constants').attr('data-nexus-media-prefix'),
+      closeImage = nexusMediaPrefix + 'nexus/img/facebox/closelabel.gif';
+
   $.extend($.facebox, {
     settings: {
       opacity      : 0.2,
       overlay      : true,
-      loadingImage : NEXUS.facebox.loadingImage,
-      closeImage   : NEXUS.facebox.closeImage,
+      loadingImage : nexusMediaPrefix + 'nexus/img/facebox/loading.gif',
+      closeImage   : closeImage,
       imageTypes   : [ 'png', 'jpg', 'jpeg', 'gif' ],
       faceboxHtml  : '\
     <div id="facebox" style="display:none;"> \
       <div class="popup"> \
         <div class="content"> \
         </div> \
-        <a href="#" class="close"><img src="' + NEXUS.facebox.closeImage + '" title="close" class="close_image" /></a> \
+        <a href="#" class="close"><img src="' + closeImage + '" title="close" class="close_image" /></a> \
       </div> \
     </div>'
     },

--- a/nexus/templates/nexus/base.html
+++ b/nexus/templates/nexus/base.html
@@ -13,18 +13,12 @@
 
         <meta name="robots" content="NONE,NOARCHIVE">
 
-        <script>
-            var NEXUS = {
-                facebox: {
-                    loadingImage: "{% nexus_media_prefix %}/nexus/img/facebox/loading.gif",
-                    closeImage:   "{% nexus_media_prefix %}/nexus/img/facebox/closelabel.png"
-                }
-            };
-        </script>
-
         <script src="{% nexus_media_prefix %}/nexus/js/lib/jquery.js"></script>
         <script src="{% nexus_media_prefix %}/nexus/js/lib/jquery.tmpl.js"></script>
-        <script src="{% nexus_media_prefix %}/nexus/js/lib/facebox/facebox.js"></script>
+        <script src="{% nexus_media_prefix %}/nexus/js/lib/facebox/facebox.js"
+                id="nexus-facebox-constants"
+                data-nexus-media-prefix="{% nexus_media_prefix %}"
+            ></script>
         <script src="{% nexus_media_prefix %}/nexus/js/nexus.js"
                 id="nexus-constants"
                 data-csrf-cookie-name="{% nexus_csrf_cookie_name %}"


### PR DESCRIPTION
To comply with the Django 1.10 JavaScript deployment guidelines and CSP without unsafe-inline.
