### PR TITLE
Remove support for Django 1.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Pending Release
 ---------------
 
 * New release notes here
+* Removed support for Django 1.7
 
 1.1.0 (2016-01-13)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Requirements
 Tested with all combinations of:
 
 * Python: 2.7, 3.4, 3.5
-* Django: 1.7 (up to Python 3.4 only), 1.8, 1.9
+* Django: 1.8, 1.9
 
 Installation
 ------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 envlist =
     py{27,35}-codestyle,
-    py{27,34,35}-django{18,19},py{27,34}-django17
+    py{27,34,35}-django{18,19}
 
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 install_command = pip install --no-deps {opts} {packages}
 deps =
-    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     -rrequirements.txt


### PR DESCRIPTION
Fixes #34. As noted on issue, it's no longer supported by Django, so we can remove it.
