### PR TITLE
Remove the need to add a call to nexus.autodiscover()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Pending Release
 
 * New release notes here
 * Removed support for Django 1.7
+* Removed the need to add a call to ``nexus.autodiscover()`` in your URLConf by using the ``AppConfig``, similar to
+  Django Admin from Django 1.7+
 
 1.1.0 (2016-01-13)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Install it with ``pip`` (or ``easy_install``):
 
 .. code-block:: bash
 
-	pip install nexus-yplan
+    pip install nexus-yplan
 
 Make sure you ``pip uninstall nexus`` first if you're upgrading from the original to this fork - the packages clash.
 
@@ -57,15 +57,12 @@ Second, include nexus at some url in your ``urls.py``:
 
 .. code-block:: python
 
-	import nexus
+    import nexus
 
-	# sets up the default nexus site by detecting all nexus_modules.py files
-	nexus.autodiscover()
-
-	# urls.py
-	urlpatterns = patterns('',
-	    ('^nexus/', include(nexus.site.urls)),
-	)
+    # urls.py
+    urlpatterns = patterns('',
+        ('^nexus/', include(nexus.site.urls)),
+    )
 
 Nexus has autodiscovery similar to Django Admin - it will look in each of your ``INSTALLED_APPS`` for a
 ``nexus_modules`` submodule, and import that. This is where the app should declare a ``NexusModule`` subclass and use

--- a/nexus/apps.py
+++ b/nexus/apps.py
@@ -8,3 +8,5 @@ class NexusAppConfig(AppConfig):
     def ready(self):
         from nexus.checks import register_checks
         register_checks()
+
+        self.module.autodiscover()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -4,9 +4,6 @@ from django.contrib import admin
 import nexus
 from nexus.compat import subinclude
 
-admin.autodiscover()
-nexus.autodiscover()
-
 urlpatterns = [
     url(r'^admin/', subinclude(admin.site.urls)),
     url(r'^nexus/', include(nexus.site.urls)),


### PR DESCRIPTION
Fixes #27. Mirrors Django Admin change from 1.7 using the AppConfig class to do this instead.
