### PR TITLE
Fix footer appearance on long pages

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Pending Release
 ---------------
 
 * New release notes here
+* Fixed footer appearance on long pages
 
 1.3.1 (2016-02-25)
 ------------------

--- a/nexus/media/css/nexus.css
+++ b/nexus/media/css/nexus.css
@@ -182,7 +182,9 @@ fieldset h2 {
     background: #f3f3f3;
 }
 
-#container { padding: 0 10px; }
+#container {
+    padding: 0 10px 50px 10px;
+}
 #container .wrapper {
     margin: 0 auto 20px;
     padding: 20px;
@@ -209,7 +211,7 @@ fieldset h2 {
     background-color: #ffffff;
     border-top: 1px solid #d5d9db;
     padding: 20px 0;
-    position: absolute;
+    position: fixed;
     bottom: 0;
     width: 100%;
 }

--- a/tests/testapp/templates/nexus/styleguide/index.html
+++ b/tests/testapp/templates/nexus/styleguide/index.html
@@ -25,4 +25,40 @@
         <button class="button delete hover">Button Delete Hover</button>
     </div>
 
+    <br><br>
+
+    <h2>Lots of Ipsum to make the page extend beyond one screen to test scrolling behaviour</h2>
+
+    <p>
+        Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+    </p>
+
+    <p>
+        Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato. Dandelion cucumber earthnut pea peanut soko zucchini.
+    </p>
+
+    <p>
+        Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress. Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke.
+    </p>
+
+    <p>
+        Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery. Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip. Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean earthnut pea sierra leone bologi leek soko chicory celtuce parsley jÃ­cama salsify.
+    </p>
+
+    <p>
+        Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed kombu beetroot horseradish carrot squash brussels sprout chard.
+    </p>
+
+    <p>
+        Pea horseradish azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn fava bean mustard tigernut jÃ­cama green bean celtuce collard greens avocado quandong fennel gumbo black-eyed pea. Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra pea winter purslane coriander yarrow sweet pepper radish garlic brussels sprout groundnut summer purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo kakadu plum komatsuna black-eyed pea green bean zucchini gourd winter purslane silver beet rock melon radish asparagus spinach.
+    </p>
+
+    <p>
+        Beetroot water spinach okra water chestnut ricebean pea catsear courgette summer purslane. Water spinach arugula pea tatsoi aubergine spring onion bush tomato kale radicchio turnip chicory salsify pea sprouts fava bean. Dandelion zucchini burdock yarrow chickpea dandelion sorrel courgette turnip greens tigernut soybean radish artichoke wattle seed endive groundnut broccoli arugula.
+    </p>
+
+    <p>
+        Soko radicchio bunya nuts gram dulse silver beet parsnip napa cabbage lotus root sea lettuce brussels sprout cabbage. Catsear cauliflower garbanzo yarrow salsify chicory garlic bell pepper napa cabbage lettuce tomato kale arugula melon sierra leone bologi rutabaga tigernut. Sea lettuce gumbo grape kale kombu cauliflower salsify kohlrabi okra sea lettuce broccoli celery lotus root carrot winter purslane turnip greens garlic. JÃ­cama garlic courgette coriander radicchio plantain scallion cauliflower fava bean desert raisin spring onion chicory bunya nuts. Sea lettuce water spinach gram fava bean leek dandelion silver beet eggplant bush tomato.
+    </p>
+
 {% endblock %}


### PR DESCRIPTION
`position: absolute` leaves it in position from the first page load when you scroll,
placing it on top of content :(
