### PR TITLE
Fix tab highlighting

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Pending Release
 
 * New release notes here
 * Fixed footer appearance on long pages
+* Fixed the tab highlighting and removed ``NexusModule.get_request`` which existed only to support the old broken code.
 
 1.3.1 (2016-02-25)
 ------------------

--- a/nexus/modules.py
+++ b/nexus/modules.py
@@ -1,10 +1,8 @@
 import hashlib
-import inspect
 import logging
 import os
 
 from django.core.urlresolvers import reverse
-from django.http import HttpRequest
 from django.utils.six.moves import _thread as thread
 
 
@@ -51,28 +49,6 @@ class NexusModule(object):
     @classmethod
     def get_global(cls, key):
         return cls._globals.get(thread.get_ident(), {}).get(key)
-
-    @classmethod
-    def get_request(cls):
-        """
-        Get the HTTPRequest object from thread storage or from a callee by searching
-        each frame in the call stack.
-        """
-        request = cls.get_global('request')
-        if request:
-            return request
-        try:
-            stack = inspect.stack()
-        except IndexError:
-            # in some cases this may return an index error
-            # (pyc files dont match py files for example)
-            return  # pragma: no cover
-        for frame, _, _, _, _, _ in stack:
-            if 'request' in frame.f_locals:
-                if isinstance(frame.f_locals['request'], HttpRequest):
-                    request = frame.f_locals['request']
-                    cls.set_global('request', request)
-                    return request
 
     def render_to_string(self, template, context={}, request=None):
         context.update(self.get_context(request))

--- a/nexus/templatetags/nexus_helpers.py
+++ b/nexus/templatetags/nexus_helpers.py
@@ -28,7 +28,7 @@ register.simple_tag(nexus_csrf_cookie_name)
 
 def show_navigation(context):
     site = context.get('nexus_site', NexusModule.get_global('site'))
-    request = NexusModule.get_request()
+    request = context['request']
 
     category_link_set = OrderedDict([(k, {
         'label': v,
@@ -41,14 +41,12 @@ def show_navigation(context):
         if module.permission and not request.user.has_perm(module.permission):
             continue
 
-        home_url = None
-        if 'request' in context:
-            home_url = module.get_home_url(context['request'])
+        home_url = module.get_home_url(context['request'])
 
         if not home_url:
             continue
 
-        # active = request.path.startswith(home_url)
+        active = request.path.startswith(home_url)
 
         if category not in category_link_set:
             if category:
@@ -60,10 +58,8 @@ def show_navigation(context):
                 'links': []
             }
 
-        # category_link_set[category]['links'].append((module.get_title(), home_url, active))  # active is broken
-        category_link_set[category]['links'].append((module.get_title(), home_url, False))
-
-        category_link_set[category]['active'] = False  # Broken: active
+        category_link_set[category]['links'].append((module.get_title(), home_url, active))
+        category_link_set[category]['active'] = active
 
     return {
         'nexus_site': site,

--- a/tests/testapp/templatetags/test_nexus_helpers.py
+++ b/tests/testapp/templatetags/test_nexus_helpers.py
@@ -1,12 +1,14 @@
 from bs4 import BeautifulSoup
-from django.template import Context, Template
-from django.test import SimpleTestCase
+from django.template import Context, RequestContext, Template
+from django.test import RequestFactory, SimpleTestCase
 
 import nexus
 from nexus.sites import site
 
 
 class NexusHelpersTests(SimpleTestCase):
+
+    request_factory = RequestFactory()
 
     def test_nexus_media_prefix(self):
         out = Template('''
@@ -23,8 +25,9 @@ class NexusHelpersTests(SimpleTestCase):
         assert out == nexus.__version__
 
     def test_show_navigation(self):
+        request = self.request_factory.get('/')
         out = Template('''
             {% load show_navigation from nexus_helpers %}
             {% show_navigation %}
-        ''').render(Context({'nexus_site': site})).strip()
+        ''').render(RequestContext(request, {'nexus_site': site})).strip()
         BeautifulSoup(out)  # checks it is valid HTML


### PR DESCRIPTION
Fixes #57. Fixes #59. Turns out to be quite simple, as long as we assume modules don't actively remove 'request' from the context, which is unlikely.
